### PR TITLE
add: pre-commit formatting hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,80 @@
+#!/usr/bin/env sh
+# Pre-commit hook: format staged files and restage them.
+
+set -euo pipefail 2>/dev/null || set -eu
+
+echo "pre-commit: collecting staged files..."
+
+staged_files=$(git diff --cached --name-only --diff-filter=ACM)
+
+# Exit early if nothing is staged.
+if [ -z "$staged_files" ]; then
+  echo "pre-commit: no staged files to check."
+  exit 0
+fi
+
+# Create temporary files to store NUL-delimited file lists.
+py_list=$(mktemp)
+js_list=$(mktemp)
+
+cleanup() {
+  rm -f "$py_list" "$js_list"
+}
+trap cleanup EXIT
+
+# Split staged files by extension.
+while IFS= read -r file; do
+  case "$file" in
+    *.py)
+      printf '%s\0' "$file" >>"$py_list"
+      ;;
+    *.js|*.ts)
+      printf '%s\0' "$file" >>"$js_list"
+      ;;
+  esac
+done <<STAGED_FILES
+$staged_files
+STAGED_FILES
+
+# Exit successfully if no matching files are staged.
+if [ ! -s "$py_list" ] && [ ! -s "$js_list" ]; then
+  echo "pre-commit: no staged .py/.js/.ts files to format."
+  exit 0
+fi
+
+# Format Python files with black.
+if [ -s "$py_list" ]; then
+  echo "pre-commit: running black on staged Python files..."
+  if ! xargs -0 black <"$py_list"; then
+    echo "pre-commit: black failed."
+    exit 1
+  fi
+fi
+
+# Format JS/TS files with prettier.
+if [ -s "$js_list" ]; then
+  echo "pre-commit: running prettier on staged JS/TS files..."
+  if ! xargs -0 prettier --write <"$js_list"; then
+    echo "pre-commit: prettier failed."
+    exit 1
+  fi
+fi
+
+# Re-add any modified files to the index.
+echo "pre-commit: restaging formatted files..."
+if [ -s "$py_list" ]; then
+  xargs -0 git add <"$py_list"
+fi
+if [ -s "$js_list" ]; then
+  xargs -0 git add <"$js_list"
+fi
+
+# Check whether there are still staged changes.
+if git diff --cached --quiet; then
+  echo "pre-commit: no staged changes remain after formatting."
+  echo "pre-commit: aborting commit so you can re-run it."
+  exit 1
+fi
+
+echo "pre-commit: formatting complete; proceeding with commit."
+exit 0


### PR DESCRIPTION
### **User description**
### Motivation
- Ensure staged Python and JS/TS files are automatically formatted before commit to maintain a consistent code style.
- Provide a tracked, shareable copy of the hook in the repository so collaborators can opt-in to the same workflow via `.githooks`.
- Prevent commits from proceeding when formatting changes are introduced without being restaged, requiring the author to re-run the commit.
- Support common formatters for the project: `black` for Python and `prettier` for JS/TS.

### Description
- Add a new executable hook at `.githooks/pre-commit` that collects staged files using `git diff --cached --name-only --diff-filter=ACM` and splits them by extension.
- Format staged `.py` files with `black` and staged `.js`/`.ts` files with `prettier`, using NUL-delimited temporary file lists and `xargs -0` for safe handling of filenames.
- Restage any files modified by the formatters with `git add`, and exit non-zero if there are no staged changes remaining after formatting to force a re-run of the commit.
- The hook is made executable (`chmod +x`) and the copy is tracked at `.githooks/pre-commit` for distribution.

### Testing
- No automated tests were run for this change because it only adds a repository hook script.
- The hook file was created and made executable in the repository, but no CI or unit tests were executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965c078e3f48332940d00ed3511f69d)


___

### **PR Type**
Enhancement


___

### **Description**
- Add executable pre-commit hook for automatic code formatting

- Formats staged Python files with `black` formatter

- Formats staged JS/TS files with `prettier` formatter

- Restages formatted files and prevents commit if no changes remain


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Staged Files"] -- "git diff --cached" --> B["Collect Files"]
  B -- "Split by extension" --> C["Python Files"]
  B -- "Split by extension" --> D["JS/TS Files"]
  C -- "black formatter" --> E["Format & Restage"]
  D -- "prettier formatter" --> E
  E -- "Check remaining changes" --> F{Changes Remain?}
  F -- "Yes" --> G["Proceed with Commit"]
  F -- "No" --> H["Abort Commit"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pre-commit</strong><dd><code>Pre-commit hook for automatic code formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.githooks/pre-commit

<ul><li>New executable shell script that runs before each commit<br> <li> Collects staged files using <code>git diff --cached --name-only </code><br><code>--diff-filter=ACM</code><br> <li> Splits files by extension and formats Python files with <code>black</code> and <br>JS/TS files with <code>prettier</code><br> <li> Restages modified files with <code>git add</code> and aborts commit if no staged <br>changes remain after formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/nnennandukwe/python-mcp-agent-workshop/pull/10/files#diff-87320095d7c4f39eed5d8f3866b512eb910e4eec8e7926faaeef6a53ab786fcb">+80/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

