### PR TITLE
fix: address Qodo code review suggestions

### DIFF
--- a/agents/performance_profiler.toml
+++ b/agents/performance_profiler.toml
@@ -178,11 +178,21 @@ output_schema = """
             "type": "object",
             "properties": {
                 "total_issues": {"type": "integer"},
-                "critical_count": {"type": "integer"},
-                "high_count": {"type": "integer"},
-                "medium_count": {"type": "integer"},
-                "low_count": {"type": "integer"},
-                "overall_assessment": {"type": "string"}
+                "by_severity": {
+                    "type": "object",
+                    "description": "Issue counts grouped by severity level",
+                    "properties": {
+                        "critical": {"type": "integer"},
+                        "high": {"type": "integer"},
+                        "medium": {"type": "integer"},
+                        "low": {"type": "integer"}
+                    }
+                },
+                "by_category": {
+                    "type": "object",
+                    "description": "Issue counts grouped by category",
+                    "additionalProperties": {"type": "integer"}
+                }
             }
         },
         "critical_issues": {


### PR DESCRIPTION
### **User description**
- Enforce mutual exclusion: validate that only one of file_path or source_code is provided, not both
- Align output_schema in performance_profiler.toml with actual summary structure (by_severity, by_category objects)
- Refactor issues_data construction to use list comprehension
- Simplify result construction for cleaner code structure


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Enforce mutual exclusion validation for file_path and source_code parameters

- Refactor issues data construction using list comprehension for cleaner code

- Simplify result construction by directly embedding JSON in response payload

- Align output_schema with actual summary structure using by_severity and by_category objects


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Parameter Validation"] -->|"Enforce mutual exclusion"| B["file_path XOR source_code"]
  C["Issues Formatting"] -->|"Use list comprehension"| D["Cleaner code structure"]
  E["Result Construction"] -->|"Simplify payload"| F["Direct JSON embedding"]
  G["Output Schema"] -->|"Align with actual structure"| H["by_severity and by_category"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix, enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.py</strong><dd><code>Enforce parameter validation and refactor response structure</code></dd></summary>
<hr>

src/workshop_mcp/server.py

<ul><li>Added validation to enforce mutual exclusion between file_path and <br>source_code parameters<br> <li> Refactored issues_data construction from loop to list comprehension <br>for improved readability<br> <li> Simplified result construction by directly embedding JSON in content <br>payload instead of separate serialization step<br> <li> Updated comment to reflect "exactly one" requirement instead of "at <br>least one"</ul>


</details>


  </td>
  <td><a href="https://github.com/nnennandukwe/python-mcp-agent-workshop/pull/21/files#diff-7f72f26c48b307f814d7428fd520b2633b6ed7fdad9bbcbd12261b02590cc8e1">+26/-14</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>performance_profiler.toml</strong><dd><code>Align output schema with actual summary structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents/performance_profiler.toml

<ul><li>Replaced individual severity count fields (critical_count, high_count, <br>medium_count, low_count) with nested by_severity object<br> <li> Added by_category object to group issue counts by category type<br> <li> Updated schema structure to match actual summary output format from <br>PerformanceChecker<br> <li> Improved schema organization with descriptive properties for grouped <br>data</ul>


</details>


  </td>
  <td><a href="https://github.com/nnennandukwe/python-mcp-agent-workshop/pull/21/files#diff-fbcc59af7ef90d5d516a1b9149091d3542428bf1e2f56daad88fb72f2d369b43">+15/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

