### PR TITLE
Coverage/server loop error paths

### DIFF
--- a/src/workshop_mcp/server.py
+++ b/src/workshop_mcp/server.py
@@ -161,8 +161,9 @@ class WorkshopMCPServer:
         if not isinstance(request, dict):
             return self._error_response(None, JsonRpcError(-32600, "Invalid Request"))
 
-        if "error" in request and request.get("id") is None:
-            return request
+        # Per JSON-RPC 2.0 spec, servers must not reply to incoming responses
+        if "error" in request:
+            return None
 
         jsonrpc = request.get("jsonrpc")
         method = request.get("method")
@@ -296,7 +297,7 @@ class WorkshopMCPServer:
                             {"required": ["source_code"]},
                         ],
                     },
-                }
+                },
             ]
         }
         return self._success_response(request_id, result)
@@ -478,9 +479,7 @@ class WorkshopMCPServer:
         if file_path and source_code:
             return self._error_response(
                 request_id,
-                JsonRpcError(
-                    -32602, "Provide only one of file_path or source_code"
-                ),
+                JsonRpcError(-32602, "Provide only one of file_path or source_code"),
             )
 
         # Type check file_path before path validation


### PR DESCRIPTION
### **PR Type**
Tests, Enhancement


___

### **Description**
- Add 34 new tests covering server.py error paths and edge cases
  - JsonRpcError.__str__ method, EOF/incomplete message handling
  - Content-Length header validation and malformed headers
  - Invalid request types, notifications, and id type validation
  - JSON-RPC version and method validation
  - Tool call and keyword_search parameter validations
  - performance_check parameter validations

- Improve server.py test coverage from 79% to 88%

- Replace 20+ manual error assertions with _assert_jsonrpc_error() helper

- Fix event loop cleanup in server fixture to prevent cross-test flakiness

- Change _encode_message signature to support JSON arrays and other types


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Suite"] -->|"adds 34 new tests"| B["Error Path Coverage"]
  B -->|"covers"| C["JsonRpcError"]
  B -->|"covers"| D["Message Framing"]
  B -->|"covers"| E["Request Validation"]
  B -->|"covers"| F["Tool Parameters"]
  G["_assert_jsonrpc_error helper"] -->|"replaces"| H["20+ manual assertions"]
  I["Event Loop Cleanup"] -->|"prevents"| J["Cross-test Flakiness"]
  K["_encode_message signature"] -->|"now supports"| L["JSON arrays"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_mcp_server_protocol.py</strong><dd><code>Comprehensive error path tests and assertion refactoring</code>&nbsp; </dd></summary>
<hr>

tests/test_mcp_server_protocol.py

<ul><li>Changed <code>_encode_message</code> signature from <code>Dict[str, Any]</code> to <code>Any</code> to <br>support JSON arrays<br> <li> Added <code>_assert_jsonrpc_error()</code> helper function for consistent error <br>validation across 20+ tests<br> <li> Added event loop cleanup (<code>asyncio.set_event_loop(None)</code>) in server <br>fixture to prevent cross-test flakiness<br> <li> Added 34 new test cases covering JsonRpcError, server loop EOF <br>handling, message framing edge cases, request validation, tool call <br>validation, keyword_search parameter validation, and performance_check <br>parameter validation<br> <li> Replaced manual error assertions with the new helper function for <br>consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/nnennandukwe/python-mcp-agent-workshop/pull/25/files#diff-70bec7e3339e46dc71d081805abf4a040d58d9578580ca24ebca2d6217c83d2e">+555/-6</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

